### PR TITLE
🪲 Add missing DISPATCH perms to arconnect request

### DIFF
--- a/src/components/WalletSelectButton.jsx
+++ b/src/components/WalletSelectButton.jsx
@@ -67,7 +67,7 @@ const WalletModal = (props) => {
   async function connectWallet(walletName) {
     switch(walletName) {
       case AR_CONNECT:
-        await window.arweaveWallet.connect(['ACCESS_ADDRESS','SIGN_TRANSACTION']);
+        await window.arweaveWallet.connect(['ACCESS_ADDRESS','SIGN_TRANSACTION','DISPATCH']);
         break;
       case ARWEAVE_APP:
         await webWallet.connect();


### PR DESCRIPTION
When the first version of the public-square-app was written, ArConnect didn't yet support `dispatch()` as a method for posting transactions. Now that they do, the app needs to request `DISPATCH` permissions.

Fixes #2 