### PR TITLE
Hardening the postInfo code to handle large posts

### DIFF
--- a/src/components/Posts.jsx
+++ b/src/components/Posts.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { abbreviateAddress, getPostTime } from '../lib/api';
+import { maxMessageLength, abbreviateAddress, getPostTime } from '../lib/api';
 
 export const Posts = (props) => {
   return (
@@ -13,7 +13,7 @@ export const Posts = (props) => {
 };
 
 const PostItem = (props) => {
-  const [postMessage, setPostMessage] = React.useState('s'.repeat(Math.max(props.postInfo.length - 75, 0)));
+  const [postMessage, setPostMessage] = React.useState("");
   const [statusMessage, setStatusMessage] = React.useState("");
 
   React.useEffect(() => {
@@ -25,24 +25,38 @@ const PostItem = (props) => {
       let isCancelled = false;
 
       const getPostMessage = async () => {
+        setPostMessage('s'.repeat(Math.min(Math.max(props.postInfo.length - 75, 0), maxMessageLength)));
         const response = await props.postInfo.request;
-        if (!response) {
-          newStatus = props.postInfo.error;
-        } else if (response.status && (response.status === 200 || response.status == 202)) {
-          props.postInfo.message = response.data;
-          newStatus = "";
-          newPostMessage = response.data;
-        } else {
-          newStatus = "missing data";
+        switch (response?.status) {
+          case 200:
+          case 202:
+            props.postInfo.message = response.data.toString();
+            newStatus = "";
+            newPostMessage = props.postInfo.message;
+            break;
+          case 404:
+            newStatus = "Not Found";
+            break;
+          default:
+            newStatus = props.postInfo?.error;
+            if(!newStatus) {
+              newStatus = "missing data";
+            }
         }
 
         if (isCancelled)
           return;
-        setStatusMessage(newStatus);
+
         setPostMessage(newPostMessage);
+        setStatusMessage(newStatus);
       }
 
-      getPostMessage();
+      if (props.postInfo.error) {
+        setPostMessage("");
+        setStatusMessage(props.postInfo.error);
+      } else {
+        getPostMessage();
+      }
       return () => isCancelled = true;
     }
     
@@ -59,9 +73,9 @@ const PostItem = (props) => {
         <img className="profileImage" src="img_avatar.png" alt="ProfileImage" />
         <div>
           <div className="postOwnerRow">
-            <Link to={`/users/${props.postInfo.owner}`}>{abbreviateAddress(props.postInfo.owner)}</Link>
-            <span className="gray"> • </span>
-            <time>{getPostTime(props.postInfo.timestamp)}</time>
+              <Link to={`/users/${props.postInfo.owner}`}>{abbreviateAddress(props.postInfo.owner)}</Link>
+              <span className="gray"> • </span>
+              <time>{getPostTime(props.postInfo.timestamp)}</time>
           </div>
           <div className="postRow">
             {props.postInfo.message || postMessage}

--- a/src/components/WalletSelectButton.jsx
+++ b/src/components/WalletSelectButton.jsx
@@ -67,7 +67,7 @@ const WalletModal = (props) => {
   async function connectWallet(walletName) {
     switch(walletName) {
       case AR_CONNECT:
-        await window.arweaveWallet.connect(['ACCESS_ADDRESS','SIGN_TRANSACTION']);
+        await window.arweaveWallet.connect(['ACCESS_ADDRESS','SIGN_TRANSACTION','DISPATCH']);
         break;
       case ARWEAVE_APP:
         await webWallet.connect();

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,6 +1,8 @@
 import Arweave from 'arweave';
 export const arweave = Arweave.init({});
 
+export const maxMessageLength = 1024;
+
 export const isWellFormattedAddress = (input) => {
   const re = /^[a-zA-Z0-9_]{43}$/;
   return re.test(input);
@@ -21,8 +23,13 @@ export const createPostInfo = (node) => {
     timestamp: timestamp,
     request: null,
   }
-  postInfo.request = arweave.api.get(`/${node.id}`, { timeout: 10000 })
-    .catch(() => { postInfo.error = "timeout loading data"});
+  if (postInfo.length <= maxMessageLength) {
+    postInfo.request = arweave.api.get(`/${node.id}`, { timeout: 10000 })
+      .catch(() => { postInfo.error = 'timeout loading data' });
+  } else {
+    postInfo.error = `message is too large (exceeds ${maxMessageLength/1024}kb)`;
+  }
+
   return postInfo;
 }
 


### PR DESCRIPTION
Some users were testing the upper limits of post message size and posted some 10MB text messages causing the timeline view to become sluggish. These updates skip downloading and displaying posts over 1MB in the timeline view.